### PR TITLE
Include plugins build step in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
           version: 12.13.0
       - name: Checkout the code
         uses: actions/checkout@v1
+      - name: Bootstrap the plugins
+        run: yarn bootstrap:plugins:all
+      - name: Build plugins
+        run: yarn build:plugins:all
       - name: Electron Builder
         uses: samuelmeuli/action-electron-builder@v1.0.0
         with:


### PR DESCRIPTION
Right now it's blocking preinstalled plugins from getting into the package